### PR TITLE
base64 デコードの際に prefix を取り除く処理を追加

### DIFF
--- a/rails/app/graphql/mutations/post_edit.rb
+++ b/rails/app/graphql/mutations/post_edit.rb
@@ -47,7 +47,8 @@ module Mutations
     private
 
       def decode_base64_image(image_url)
-        decoded_data = Base64.decode64(image_url)
+        body = image_url.split(",")[1]
+        decoded_data = Base64.decode64(body)
         filename = "image_#{SecureRandom.uuid}.png"
         filepath = Rails.root.join("public", "uploads", filename) # 'public/uploads'ディレクトリに保存
         File.open(filepath, "wb") do |f|


### PR DESCRIPTION
# 修正点

修正点としては下記の通りです。

## base64 のデコードの方法を修正

フロント側からbase64を渡してサーバ側で保存を行なっていますが、その際のデコードが正しく行われていないのでファイルが壊れていました。

具体的にはフロント側から送信されたbase64 は `data:image/png;base64,iVBORw0KGgoAAAANSUh.... ` のように prefix がついた形になっているのでそのprefix 部分を取り除く必要があるのでこの処理を追加しました。

## フロント側で api のURL を追加

画像表示の際に URL が `/uploads/post/image_url/2/image_68b79f50-b6fc-43c1-a96f-46e50d70b570.png` のようになっているのですが、そのままだとフロントサーバを見に行ってしまうので先頭に `http://localhost:3000' (API の URL) を追加するように変更しました。


# そのほか気になる点


## 新規投稿の際のバリデーションがうまく動いていない。

新規投稿の際のバリデーションがうまく行っておらずこちらで触っている限りは、うまくフォームを送信することができませんでした。（修正の際には一旦バリデーションの処理をコメントアウトして動作確認を行いました。)

imageUrl や isPublic 部分の zod のバリデーションがうまく行っていないせいでエラーになっているようです。

## サーバ側でのファイルの保存について

carrierwave の設定で参照するための実ファイルは、`/uploads/post/image_url/2/image_68b79f50-b6fc-43c1-a96f-46e50d70b570.png` のようなパスになっていますが base64 デコード時に作成したファイルが `/uploads` [直下に残ってしまう書き方](https://github.com/masahiro96848/dev-post-backend/blob/main/rails/app/graphql/mutations/post_edit.rb#L53)になってしまっているのでファイルの保存が終了次第 /uploads 直下のファイルは削除できると良いかと思います。

